### PR TITLE
fix: getattr bug

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -119,5 +119,9 @@ func getMounts(c *cli.Context, readOnly bool) (mounts.UserMounts, func(), error)
 		return nil, func() {}, fmt.Errorf("failed creating beestore %w", err)
 	}
 
-	return mounts.New(lookuper.New(fStore, owner), publisher.New(fStore, signer), bStore), func() { bStore.Close() }, nil
+	return mounts.New(
+		lookuper.New(fStore, owner),
+		publisher.New(fStore, signer, lookuper.Latest(fStore, owner)),
+		bStore,
+	), func() { bStore.Close() }, nil
 }

--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -145,7 +145,7 @@ func getCachedLookuperPublisher(c *cli.Context, b store.PutGetter, batch string)
 	}
 
 	lk := lookuper.New(fStore, owner)
-	pb := publisher.New(fStore, signer)
+	pb := publisher.New(fStore, signer, lookuper.Latest(fStore, owner))
 
 	cachedLkPb, err := cached.New(lk, pb, 5*time.Second)
 	if err != nil {

--- a/pkg/file/file_test.go
+++ b/pkg/file/file_test.go
@@ -253,6 +253,33 @@ func TestFileHybrid(t *testing.T) {
 			t.Fatal("read bytes not equal")
 		}
 	})
+
+	t.Run("truncate", func(t *testing.T) {
+		sz := len(testBuf) - 1024
+		err := f.Truncate(int64(sz))
+		if err != nil {
+			t.Fatalf("failed executing truncate call %v", err)
+		}
+
+		ref, err := f.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		f2 := file.New(ref, st, false)
+
+		newBuf := make([]byte, len(testBuf))
+		n, err := f2.Read(newBuf)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if n != sz {
+			t.Fatalf("invalid length of read exp: %d found: %d", sz, n)
+		}
+		if bytes.Compare(newBuf[:sz], testBuf[:sz]) != 0 {
+			t.Fatal("read bytes not equal")
+		}
+	})
 }
 
 func TestFileReader(t *testing.T) {

--- a/pkg/fuse/fuse_test.go
+++ b/pkg/fuse/fuse_test.go
@@ -48,7 +48,7 @@ func newTestFs(st store.PutGetter) (*fs.BeeFs, string, func(), error) {
 	}
 
 	lk := lookuper.New(st, owner)
-	pb := publisher.New(st, signer)
+	pb := publisher.New(st, signer, lookuper.Latest(st, owner))
 	cLkPb, err := cached.New(lk, pb, time.Second)
 	if err != nil {
 		return nil, "", func() {}, err

--- a/pkg/fuse/fuse_test.go
+++ b/pkg/fuse/fuse_test.go
@@ -82,7 +82,7 @@ func newTestFs(st store.PutGetter) (*fs.BeeFs, string, func(), error) {
 	}, nil
 }
 
-func TestFileBasic(t *testing.T) {
+func TestFileSystemBasic(t *testing.T) {
 	st := mock.NewStorer()
 	_, mntDir, closer, err := newTestFs(st)
 	if err != nil {
@@ -90,38 +90,49 @@ func TestFileBasic(t *testing.T) {
 	}
 	defer closer()
 
-	time.Sleep(time.Second)
+	t.Run("create directory", func(t *testing.T) {
+		err := os.Mkdir(filepath.Join(mntDir, "dir1"), 0755)
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
 
 	content := []byte("hello world")
-	fn := filepath.Join(mntDir, "file1")
+	fn := filepath.Join(mntDir, "dir1/file1")
 
-	if err := os.WriteFile(fn, content, 0755); err != nil {
-		t.Fatalf("WriteFile: %v", err)
-	}
-	if got, err := os.ReadFile(fn); err != nil {
-		t.Fatalf("ReadFile: %v", err)
-	} else if bytes.Compare(got, content) != 0 {
-		t.Fatalf("ReadFile: got %q, want %q", got, content)
-	}
+	t.Run("create file", func(t *testing.T) {
+		if err := os.WriteFile(fn, content, 0755); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+	})
 
-	f, err := os.Open(fn)
-	if err != nil {
-		t.Fatalf("Open: %v", err)
-	}
-	defer f.Close()
+	t.Run("read file", func(t *testing.T) {
+		if got, err := os.ReadFile(fn); err != nil {
+			t.Fatalf("ReadFile: %v", err)
+		} else if bytes.Compare(got, content) != 0 {
+			t.Fatalf("ReadFile: got %q, want %q", got, content)
+		}
+	})
 
-	fi, err := f.Stat()
-	if err != nil {
-		t.Fatalf("Fstat: %v", err)
-	} else if int(fi.Size()) != len(content) {
-		t.Errorf("got size %d want 5", fi.Size())
-	}
-	if got, want := uint32(fi.Mode()), uint32(0755); got != want {
-		t.Errorf("Fstat: got mode %o, want %o", got, want)
-	}
-	if err := f.Close(); err != nil {
-		t.Errorf("Close: %v", err)
-	}
+	t.Run("file stat", func(t *testing.T) {
+		f, err := os.Open(fn)
+		if err != nil {
+			t.Fatalf("Open: %v", err)
+		}
+
+		fi, err := f.Stat()
+		if err != nil {
+			t.Fatalf("Fstat: %v", err)
+		} else if int(fi.Size()) != len(content) {
+			t.Errorf("got size %d want 5", fi.Size())
+		}
+		if got, want := uint32(fi.Mode()), uint32(0755); got != want {
+			t.Errorf("Fstat: got mode %o, want %o", got, want)
+		}
+		if err := f.Close(); err != nil {
+			t.Errorf("Close: %v", err)
+		}
+	})
 }
 
 func TestMultiDirWithFiles(t *testing.T) {

--- a/pkg/lookuper/lookuper_test.go
+++ b/pkg/lookuper/lookuper_test.go
@@ -2,6 +2,7 @@ package lookuper_test
 
 import (
 	"context"
+	"encoding/binary"
 	"fmt"
 	"testing"
 	"time"
@@ -34,6 +35,8 @@ func TestLookuper(t *testing.T) {
 
 	lkpr := lookuper.New(st, owner)
 
+	var lastUpdate int64
+
 	for i := 1; i <= 3; i++ {
 		now := time.Now().Unix()
 		ref := swarm.MustParseHexAddress(fmt.Sprintf("%d000000000000000000000000000000000000000000000000000000000000000", i))
@@ -50,12 +53,13 @@ func TestLookuper(t *testing.T) {
 			if !ref2.Equal(ref) {
 				t.Fatalf("lookup returned invalid ref exp %s found %s", ref.String(), ref2.String())
 			}
+			lastUpdate = now
 		})
 	}
 
 	time.Sleep(time.Second)
 
-	t.Run("latest", func(t *testing.T) {
+	t.Run("latest get", func(t *testing.T) {
 		ref, err := lkpr.Get(context.TODO(), testID, time.Now().Unix())
 		if err != nil {
 			t.Fatal(err)
@@ -63,6 +67,24 @@ func TestLookuper(t *testing.T) {
 		exp := swarm.MustParseHexAddress("3000000000000000000000000000000000000000000000000000000000000000")
 		if !ref.Equal(exp) {
 			t.Fatalf("lookup returned invalid ref exp %s found %s", exp.String(), ref.String())
+		}
+	})
+
+	t.Run("latest", func(t *testing.T) {
+		latestFn := lookuper.Latest(st, owner)
+		idx, at, err := latestFn(context.TODO(), testID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		buf, err := idx.MarshalBinary()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if binary.BigEndian.Uint64(buf) != 2 {
+			t.Fatalf("incorrect index %s exp %d", idx, 2)
+		}
+		if at != lastUpdate {
+			t.Fatalf("incorrect timestamp found %d exp %d", at, lastUpdate)
 		}
 	})
 }

--- a/pkg/publisher/publisher.go
+++ b/pkg/publisher/publisher.go
@@ -2,12 +2,13 @@ package publisher
 
 import (
 	"context"
+	"encoding/binary"
 	"fmt"
+	"strconv"
 	"sync"
 
 	"github.com/ethersphere/bee/pkg/crypto"
 	"github.com/ethersphere/bee/pkg/feeds"
-	"github.com/ethersphere/bee/pkg/feeds/sequence"
 	"github.com/ethersphere/bee/pkg/storage"
 	"github.com/ethersphere/bee/pkg/swarm"
 	logger "github.com/ipfs/go-log/v2"
@@ -19,36 +20,90 @@ type Publisher interface {
 	Put(ctx context.Context, id string, version int64, ref swarm.Address) error
 }
 
+type Loader func(ctx context.Context, id string) (feeds.Index, int64, error)
+
 type pubImpl struct {
 	putter     storage.Putter
 	signer     crypto.Signer
+	loader     Loader
 	updaterMap sync.Map
 }
 
-func New(putter storage.Putter, signer crypto.Signer) Publisher {
-	return &pubImpl{putter: putter, signer: signer}
+type feedState struct {
+	currIndex feeds.Index
+	ts        int64
+}
+
+func New(putter storage.Putter, signer crypto.Signer, loader Loader) Publisher {
+	return &pubImpl{putter: putter, signer: signer, loader: loader}
 }
 
 func (p *pubImpl) Put(ctx context.Context, id string, version int64, ref swarm.Address) error {
-	upd, err := p.updater(id)
+	var nxtIndex feeds.Index
+
+	state, found := p.updaterMap.Load(id)
+	if !found {
+		currIndex, at, err := p.loader(ctx, id)
+		if err == nil {
+			nxtIndex = currIndex.Next(at, uint64(version))
+		} else {
+			nxtIndex = new(index)
+		}
+	} else {
+		fstate := state.(feedState)
+		nxtIndex = fstate.currIndex.Next(fstate.ts, uint64(version))
+	}
+
+	err := p.update(ctx, id, version, nxtIndex, ref.Bytes())
+	if err != nil {
+		return fmt.Errorf("publisher: failed to update next index: %w", err)
+	}
+
+	p.updaterMap.Store(id, feedState{currIndex: nxtIndex, ts: version})
+
+	log.Debugf("updated id %s version %d ref %s", id, version, ref.String())
+
+	return nil
+}
+
+func (p *pubImpl) update(
+	ctx context.Context,
+	id string,
+	version int64,
+	idx feeds.Index,
+	payload []byte,
+) error {
+	putter, err := feeds.NewPutter(p.putter, p.signer, []byte(id))
 	if err != nil {
 		return err
 	}
 
-	log.Debugf("updating id %s version %d ref %s", id, version, ref.String())
+	err = putter.Put(ctx, idx, version, payload)
+	if err != nil {
+		return err
+	}
 
-	return upd.Update(ctx, version, ref.Bytes())
+	return nil
 }
 
-func (p *pubImpl) updater(id string) (feeds.Updater, error) {
-	upd, found := p.updaterMap.Load(id)
-	if !found {
-		var err error
-		upd, err = sequence.NewUpdater(p.putter, p.signer, []byte(id))
-		if err != nil {
-			return nil, fmt.Errorf("failed creating new updater %w", err)
-		}
-		p.updaterMap.Store(id, upd)
-	}
-	return upd.(feeds.Updater), nil
+// index replicates the feeds.sequence.Index. This index creation is not exported from
+// the package as a result loader doesn't know how to return the first feeds.Index.
+// This index will be used to return which will provide a compatible interface to
+// feeds.sequence.Index.
+type index struct {
+	index uint64
+}
+
+func (i *index) String() string {
+	return strconv.FormatUint(i.index, 10)
+}
+
+func (i *index) MarshalBinary() ([]byte, error) {
+	indexBytes := make([]byte, 8)
+	binary.BigEndian.PutUint64(indexBytes, i.index)
+	return indexBytes, nil
+}
+
+func (i *index) Next(last int64, at uint64) feeds.Index {
+	return &index{i.index + 1}
 }

--- a/pkg/publisher/publisher.go
+++ b/pkg/publisher/publisher.go
@@ -14,7 +14,7 @@ import (
 	logger "github.com/ipfs/go-log/v2"
 )
 
-var log = logger.Logger("lookuper")
+var log = logger.Logger("publisher")
 
 type Publisher interface {
 	Put(ctx context.Context, id string, version int64, ref swarm.Address) error
@@ -45,6 +45,7 @@ func (p *pubImpl) Put(ctx context.Context, id string, version int64, ref swarm.A
 	if !found {
 		currIndex, at, err := p.loader(ctx, id)
 		if err == nil {
+			log.Infof("publisher: loaded initial version %s timestamp %d", currIndex, at)
 			nxtIndex = currIndex.Next(at, uint64(version))
 		} else {
 			nxtIndex = new(index)

--- a/pkg/publisher/publisher_test.go
+++ b/pkg/publisher/publisher_test.go
@@ -3,6 +3,7 @@ package publisher_test
 import (
 	"context"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -14,11 +15,11 @@ import (
 	"github.com/ethersphere/bee/pkg/feeds/sequence"
 	"github.com/ethersphere/bee/pkg/storage/mock"
 	"github.com/ethersphere/bee/pkg/swarm"
-	logger "github.com/ipfs/go-log/v2"
 )
 
 func TestPublisher(t *testing.T) {
-	logger.SetLogLevel("*", "Error")
+	t.Parallel()
+
 	st := mock.NewStorer()
 
 	pk, _ := crypto.GenerateSecp256k1Key()
@@ -29,33 +30,101 @@ func TestPublisher(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	pub := publisher.New(st, signer)
+	t.Run("new", func(t *testing.T) {
+		pub := publisher.New(
+			st,
+			signer,
+			func(_ context.Context, _ string) (feeds.Index, int64, error) {
+				return nil, 0, errors.New("some error")
+			},
+		)
 
-	for pfx, id := range []string{"test1", "test2", "test3"} {
-		lk := sequence.NewFinder(st, feeds.New([]byte(id), owner))
-		var hint int64
-		for idx := 0; idx < 3; idx++ {
-			t.Run(fmt.Sprintf("topic=%s/idx=%d", id, idx), func(t *testing.T) {
-				ref := swarm.MustParseHexAddress(fmt.Sprintf("%d%d00000000000000000000000000000000000000000000000000000000000000", pfx, idx))
-				err := pub.Put(context.TODO(), id, time.Now().Unix(), ref)
-				if err != nil {
-					t.Fatal(err)
-				}
-				time.Sleep(time.Second)
-				ch, current, _, err := lk.At(context.TODO(), time.Now().Unix(), hint)
-				if err != nil {
-					t.Fatal(err)
-				}
-				ref2, _, err := lookuper.ParseFeedUpdate(ch)
-				if err != nil {
-					t.Fatal(err)
-				}
-				if !ref2.Equal(ref) {
-					t.Fatalf("incorrect ref in lookup exp %s found %s", ref.String(), ref2.String())
-				}
-				buf, _ := current.MarshalBinary()
-				hint = int64(binary.BigEndian.Uint64(buf))
-			})
+		for pfx, id := range []string{"test1", "test2", "test3"} {
+			lk := sequence.NewFinder(st, feeds.New([]byte(id), owner))
+			var hint int64
+			for idx := 0; idx < 3; idx++ {
+				t.Run(fmt.Sprintf("topic=%s/idx=%d", id, idx), func(t *testing.T) {
+					ref := swarm.MustParseHexAddress(
+						fmt.Sprintf(
+							"%d%d00000000000000000000000000000000000000000000000000000000000000",
+							pfx, idx,
+						),
+					)
+					err := pub.Put(context.TODO(), id, time.Now().Unix(), ref)
+					if err != nil {
+						t.Fatal(err)
+					}
+					time.Sleep(time.Second)
+					ch, current, _, err := lk.At(context.TODO(), time.Now().Unix(), hint)
+					if err != nil {
+						t.Fatal(err)
+					}
+					ref2, _, err := lookuper.ParseFeedUpdate(ch)
+					if err != nil {
+						t.Fatal(err)
+					}
+					if !ref2.Equal(ref) {
+						t.Fatalf("incorrect ref in lookup exp %s found %s", ref.String(), ref2.String())
+					}
+					buf, _ := current.MarshalBinary()
+					hint = int64(binary.BigEndian.Uint64(buf))
+				})
+			}
 		}
-	}
+	})
+
+	t.Run("existing state", func(t *testing.T) {
+		pub := publisher.New(
+			st,
+			signer,
+			func(ctx context.Context, id string) (feeds.Index, int64, error) {
+				lk := sequence.NewFinder(st, feeds.New([]byte(id), owner))
+				ch, start, _, err := lk.At(ctx, time.Now().Unix(), 0)
+				if err != nil {
+					return nil, 0, err
+				}
+				if ch == nil {
+					return nil, 0, errors.New("invalid chunk")
+				}
+				_, ts, err := lookuper.ParseFeedUpdate(ch)
+				if err != nil {
+					return nil, 0, err
+				}
+				return start, ts, nil
+			},
+		)
+
+		for pfx, id := range []string{"test1", "test2", "test3"} {
+			lk := sequence.NewFinder(st, feeds.New([]byte(id), owner))
+			var hint int64
+			for idx := 3; idx < 6; idx++ {
+				t.Run(fmt.Sprintf("topic=%s/idx=%d", id, idx), func(t *testing.T) {
+					ref := swarm.MustParseHexAddress(
+						fmt.Sprintf(
+							"%d%d00000000000000000000000000000000000000000000000000000000000000",
+							pfx, idx,
+						),
+					)
+					err := pub.Put(context.TODO(), id, time.Now().Unix(), ref)
+					if err != nil {
+						t.Fatal(err)
+					}
+					time.Sleep(time.Second)
+					ch, current, _, err := lk.At(context.TODO(), time.Now().Unix(), hint)
+					if err != nil {
+						t.Fatal(err)
+					}
+					ref2, _, err := lookuper.ParseFeedUpdate(ch)
+					if err != nil {
+						t.Fatal(err)
+					}
+					if !ref2.Equal(ref) {
+						t.Fatalf("incorrect ref in lookup exp %s found %s", ref.String(), ref2.String())
+					}
+					buf, _ := current.MarshalBinary()
+					hint = int64(binary.BigEndian.Uint64(buf))
+				})
+			}
+		}
+	})
 }


### PR DESCRIPTION
FUSE Getattr call may or may not have a valid file handle. If the filehandle is not valid, we need to see if there is an open filehandle for this path. If it is available, we should use the inmem state as this will be populated with the latest stat information.